### PR TITLE
Changes to export format to be in line with lean4checker,

### DIFF
--- a/src/export_format.md
+++ b/src/export_format.md
@@ -49,7 +49,7 @@ Expr ::=
   | eidx "#ES"  uidx
   | eidx "#EC"  nidx uidx*
   | eidx "#EA"  eidx eidx
-  | eidx "#EL"  Info nidx eidx
+  | eidx "#EL"  Info nidx eidx eidx
   | eidx "#EP"  Info nidx eidx eidx
   | eidx "#EZ"  Info nidx eidx eidx eidx
   | eidx "#EJ"  nidx nat eidx
@@ -66,7 +66,7 @@ RecRule ::= ridx "#RR" (ctorName : nidx) (nFields : nat) (val : eidx)
 
 Axiom ::= "#AX" (name : nidx) (type : eidx) (uparams : uidx*)
 
-Def ::= "#DEF" (name : nidx) (type : eidx) (value : eidx) (hint : Hint) (uparams : uidx*)
+Def ::= "#DEF" (name : nidx) (type : eidx) (value : eidx) (hint : Hint)? (uparams : uidx*)
   
 Theorem ::= "#THM" (name : nidx) (type : eidx) (value : eidx) (uparams: uidx*)
 


### PR DESCRIPTION
Hi, thanks for writing this incredible resource. I have an OCaml parser written using the grammar spec that you have in `export_format.md` which seems to fail on output generated by `lean4export`. The two failures I noticed were the following: 

### Export format for Lambdas 

There seems to be a bug in the specification for `#EL` declarations. The text says: 
```
eidx "#EL"  Info nidx eidx
```  
But in the [lean4export (L73)](https://github.com/leanprover/lean4export/blob/d7978498941853b4ff8003b058f66e2142d3a763/Export.lean#L73) I see something more akin to:
```
eidx "#EL"  Info nidx eidx eidx
```  
which is identical to the binder info for Pi types. 


### Export format for Defs

This spec for definitions: 
```
Def ::= "#DEF" (name : nidx) (type : eidx) (value : eidx) (hint : Hint) (uparams : uidx*)
```
makes it seem like hints are mandatory, however according to [lean4export L95-L105](https://github.com/leanprover/lean4export/blob/master/Export.lean#L95-L105) it seems like this is more appropriate:
```
Def ::= "#DEF" (name : nidx) (type : eidx) (value : eidx) (hint : Hint)? (uparams : uidx*)
```
In other words, aren't hints optional?

Do let me know if I missed something, and thank you very much for writing this amazing book!