### PR TITLE
Add some more changes to the export format

### DIFF
--- a/src/export_format.md
+++ b/src/export_format.md
@@ -56,7 +56,7 @@ Expr ::=
   | eidx "#EA"  eidx eidx
   | eidx "#EL"  Info nidx eidx eidx
   | eidx "#EP"  Info nidx eidx eidx
-  | eidx "#EZ"  Info nidx eidx eidx eidx
+  | eidx "#EZ"  nidx eidx eidx eidx
   | eidx "#EJ"  nidx nat eidx
   | eidx "#ELN" nat
   | eidx "#ELS" (hexhex)*
@@ -72,6 +72,8 @@ RecRule ::= ridx "#RR" (ctorName : nidx) (nFields : nat) (val : eidx)
 Axiom ::= "#AX" (name : nidx) (type : eidx) (uparams : uidx*)
 
 Def ::= "#DEF" (name : nidx) (type : eidx) (value : eidx) (hint : Hint) (uparams : uidx*)
+
+Opaq ::= "#OPAQ" (name : nidx) (type : eidx) (value : eidx) (uparams : uidx*)
   
 Theorem ::= "#THM" (name : nidx) (type : eidx) (value : eidx) (uparams: uidx*)
 


### PR DESCRIPTION
Hi Chris, 

I had some more time to get back to my parser. I am trying it out on parsing the `lean4export`ed output of `Init.lean` (using your fork).

As I was doing this I noticed a few things that were missing in the grammar specification in `export_format.md`. In particular, `#OPAQ`s are not mentioned, and it seems like `#EZ` exprs do not have any `Info` field. 

Could you confirm if I got those right? 

Kody  