### PR TITLE
Remove a portion saying structures cannot be recursive

### DIFF
--- a/src/expressions/expressions.md
+++ b/src/expressions/expressions.md
@@ -140,7 +140,7 @@ An exceedingly common kernel operation for manipulating expressions is folding a
 
 ### Projections
 
-The `proj` constructor represents structure projections. Inductive types that are not recursive, have only one constructor, and have no indices can be structures.
+The `proj` constructor represents structure projections. Inductive types that have only one constructor and have no indices can be structures.
 
 The constructor takes a name, which is the name of the type, a natural number indicating the field being projected, and the actual structure the projection is being applied to.
 


### PR DESCRIPTION
Compared with the [reference](https://lean-lang.org/doc/reference/4.21.0//The-Type-System/Inductive-Types/#structures) which now says:

> Structures are inductive types that have only a single constructor and no indices. [...] Just like other inductive types, structures may be recursive; they are subject to the same restrictions regarding strict positivity. 